### PR TITLE
Faraday version update

### DIFF
--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '~> 1.8'
   spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1'
   spec.add_runtime_dependency 'beaker', '~> 2.1', '>= 2.1.0'
-  spec.add_runtime_dependency 'faraday', '~> 0.9'
+  spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'
   spec.add_runtime_dependency 'nokogiri', '~> 1.5', '>= 1.5.10'


### PR DESCRIPTION
Logger requires 0.9.1, was not working with 0.9.0
