### PR TITLE
Fix middleware logger ordering

### DIFF
--- a/lib/scooter/httpdispatchers/consoledispatcher.rb
+++ b/lib/scooter/httpdispatchers/consoledispatcher.rb
@@ -82,10 +82,10 @@ module Scooter
 
           # This logger will need to be configurable somehow..., maybe based on
           # beaker log-level?
-          conn.response :logger, nil, bodies: true
           conn.response :follow_redirects
           conn.response :json, :content_type => /\bjson$/
           conn.response :raise_error
+          conn.response :logger, nil, bodies: true
 
           conn.use :cookie_jar
 


### PR DESCRIPTION
This allows for the body of http responses to be sent to the logger
before the error handling middleware catches it.
