### PR TITLE
(maint) remove httparty require

### DIFF
--- a/lib/scooter.rb
+++ b/lib/scooter.rb
@@ -1,5 +1,4 @@
 require 'scooter/version'
-require 'httparty'
 require 'beaker'
 require 'net/ldap'
 require 'faraday'


### PR DESCRIPTION
Since scooter now uses farady, it no longer requires httparty. This
commit removes a left over `require httparty`.
