### PR TITLE
Bump version to major y release

### DIFF
--- a/lib/scooter/version.rb
+++ b/lib/scooter/version.rb
@@ -1,3 +1,3 @@
 module Scooter
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
0.1.x will support PE 3.7 and PE 3.8. 0.2.x will support PE 4.0 and will
live on a separate branch.
