### PR TITLE
(maint) use reachable_name for farady connection

### DIFF
--- a/lib/scooter/httpdispatchers/consoledispatcher.rb
+++ b/lib/scooter/httpdispatchers/consoledispatcher.rb
@@ -110,7 +110,7 @@ module Scooter
 
       def set_host_and_port(connection=@connection)
         connection.url_prefix.scheme = 'https'
-        connection.url_prefix.host = "#{@dashboard}"
+        connection.url_prefix.host = "#{@dashboard.reachable_name}"
 
         if is_certificate_dispatcher?
           connection.url_prefix.port = 4433


### PR DESCRIPTION
Previous to this commit, the farady connection method was just using
`@dashboard`. However, beaker returns the node_name by default. This
works so long as the dashboard host is in your `/etc/hosts` file.
This commit changes it to use `dashboard.reachable_name` - which
defaults to IP address then hostname and is what beaker uses to
establish an ssh connection.
