### PR TITLE
Bump version for reachable name bug fixes

### DIFF
--- a/lib/scooter/version.rb
+++ b/lib/scooter/version.rb
@@ -1,3 +1,3 @@
 module Scooter
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Version 0.1.2 adds logic to test the resolvability of the dashboard and
uses reachable_name if necessary, plus a bug fix for update-classes.
