### PR TITLE
(maint) fix ldap host logic to work with beaker 2.11.0

### DIFF
--- a/lib/scooter/ldap.rb
+++ b/lib/scooter/ldap.rb
@@ -48,10 +48,10 @@ module Scooter
         # All initialized LDAPDispatcher objects will have test_uids to ensure
         # no collisions when creating entries in the directory services.
         @test_uid = Scooter::Utilities::RandomString.generate(4)
-        if host.is_a? Unix::Host
-          @ds_type = :openldap
-        elsif host.is_a? Windows::Host
+        if host.is_a? Windows::Host
           @ds_type = :ad
+        elsif host.is_a? Unix::Host
+          @ds_type = :openldap
         else
           raise "host must be Unix::Host or Windows::Host, not #{host.class}"
         end


### PR DESCRIPTION
Beaker 2.11.0 introduced a change in the object inheritance for the
Windows::Host object, making it inherit from Unix::Host. This commit
changes the order of checks in the ldapdispatcher object, making it
check for Windows first before checking if it is a Unix::Host.
