### PR TITLE
Add `#find_or_create_node_group_model`

### DIFF
--- a/lib/scooter/httpdispatchers/classifier.rb
+++ b/lib/scooter/httpdispatchers/classifier.rb
@@ -117,6 +117,25 @@ module Scooter
         create_node_group(hash).env.body
       end
 
+      # This takes an optional hash of node group parameters. If a "name" option
+      # is provided it will attempt to find an existing node group with that
+      # name in the environment specified in the "environment" option (default:
+      # "production").
+      #
+      # If an existing node group is found, it will be updated according to the
+      # provided options (via `#replace_node_group_with_update_hash`).
+      #
+      # If no existing node group is found, the options hash will be used to
+      # create a new node group (via `#create_new_node_group_model`).
+      def find_or_create_node_group_model(options={})
+        options["environment"] ||= "production"
+        if options["name"] && existing = get_node_group_by_name(options["name"], options["environment"])
+          replace_node_group_with_update_hash(existing, options)
+        else
+          create_new_node_group_model(options)
+        end
+      end
+
       # If for some reason your node group model is out of sync with the
       # server's state for that node group, you can use this method to just
       # update your model with the server state.


### PR DESCRIPTION
![](http://image.slidesharecdn.com/owc-automate-no-notes-120714165353-phpapp01/95/automate-all-the-things-1-728.jpg?cb=1342284908)

In https://github.com/puppetlabs/pe_acceptance_tests/pull/614 we locally introduced a `#find_or_create_node_group_model` method on the dispatcher classifier module. This allows us to re-run tests which create node groups in the classifier, without causing errors due to duplicate node groups in an environment.

This brings that method back to `Scooter::HttpDispatchers::Classifier`.

/cc @objectverbobject @ericwilliamson @doug-rosser 

p.s. I notice a sincere lack of tests for this area of functionality :person_frowning: 
