### PR TITLE
Import confluence documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # Scooter
 
+#### Table of Contents
+
+1. [Overview](#overview)
+2. [Usage](#usage)
+3. [Versioning](#versioning)
+4. [Releasing](#releasing)
+  * [Pushing a new version to the internal rubygems mirror](#pushing-a-new-version-to-the-internal-rubygems-mirror)
+5. [Rdocs](#rdocs)
+6. [Contributing](#contributing)
+
+## Overview
+
 Scooter is a ruby gem developed by QA to facilitate http traffic between the
 test runner and a Puppet Enterprise Installation–specifically the services
 available in the pe-console-services process: Classifier, RBAC, and Activity
@@ -7,6 +19,62 @@ Service.
 
 ## Usage
 
-TODO: Import Confluence Documentation into repo
+Scooter only supports versions of Puppet Enterprise 3.7 and higher. Scooter is only available on the internal server, rubygems.delivery.puppetlabs.net.
 
-Confluence Link: https://confluence.puppetlabs.com/display/QA/Scooter
+To install Scooter, simply use the gem command with the source flag set to the internal rubygems mirror–remember that you will have to be on Puppet's DNS to see the mirrored gem server.
+
+```
+$ gem install scooter --source http://rubygems.delivery.puppetlabs.net
+```
+
+Scooter is currently divvied into the following sections:
+
+ - [HttpDispatchers](docs/http_dispatchers.md) – These are modules that can be mixed into classes that represent real users: whitelisted certificate users, local console users, or users connected through an LDAP directory. Currently, there is only one dispatcher currently defined--ConsoleDispatcher–but there could be new dispatchers created to facilitate traffic to other products, such as Puppet Server and PuppetDB.
+
+ - LDAPdispatcher – This class extends the Net::LDAP library, which is a requirement to for RBAC testing with LDAP fixtures.
+ - Utilities – Currently, this houses random string generators and convenience methods to use beaker to acquire certificates to impersonate whitelisted certificate users.
+
+## Versioning
+
+Scooter supports semantic versioning, with any 1.x release of scooter supporting all PE versions between 3.7.x and 4.0.
+
+If you are looking for scooter support for PE 4.0 aka shallow gravy, please use any scooter version that is 2.x. Routes to the services changed between PE 3.7 and PE 4.0, requiring a major version bump of scooter between those versions.
+
+## Releasing
+
+The plan is to release Scooter at a regular cadence, probably once a week. Early on, we will release more often, as the port from qatests is not totally complete. Early feedback may significantly change the structure, so be cautious about building any significant dependencies yet. Once the dust has settled, a 1.0 release will be cut and support normal semantic versioning.
+
+Discussion is still ongoing about whether this library will be publicly available on rubygems or not. Please feel free to email the the QA team for any further information regarding a public release.
+
+ - One issue blocking a public release of Scooter is to avoid possibly leaking information about unreleased features/products that Scooter might have information on. This could be mitigated by careful version control of Scooter, releasing it to the public only periodically, but releasing internally at a more frequent basis for internal testing.
+
+ - Should the gem accept PR's from the public? That seems to require significant overhead in terms of testing and stability of PR's. Perhaps make the gem public without accepting PR's from the public? Make the gem available on rubygems.org while the repo stays private?
+
+### Pushing a new version to the internal rubygems mirror
+
+ 1. Log into jenkins-qe
+
+ 2. Trigger the Scooter Release Pipeline
+
+   a. The pipeline is responsible for checking in the version bump, generating a new HISTORY.md file, creating and pushing the gem
+
+   b. Select an appropriate version number *** WARNING - whatever version number you select will be auto-created and pushed liver, BE CAREFUL ***
+
+## Rdocs
+
+Much of the documentation of Scooter is embedded in the ruby code itself, using rdoc standards for documentation. Currently, Puppet does not have an internal server delivering yard documentation; if you wish to view the rdocs, you must build it out yourself after you have downloaded the gem.
+
+```
+prompt:~$ yard server --gems
+
+#>> YARD 0.8.7.4 documentation server at http://0.0.0.0:8808
+#Thin web server (v1.6.2 codename Doc Brown)
+#Maximum connections set to 1024
+#Listening on 0.0.0.0:8808, CTRL+C to stop
+#
+#goto: http://0.0.0.0:8808/docs/scooter/frames
+```
+
+## Contributing
+
+You are encouraged to fork and submit PR's to Scooter. Tony Vu or Chris Cowell-Shah are your best bet for getting a PR merged in; that list will grow as QA adds more regular contributors to the repo.

--- a/docs/http_dispatchers.md
+++ b/docs/http_dispatchers.md
@@ -1,0 +1,79 @@
+## HttpDispatchers
+
+### Overview
+
+Currently, there is only one class available in this section, the [`ConsoleDispatcher`](#console-dispatcher). A few, general ideas about the organization and procedure are as follows (All of this page needs better organization):
+
+The underlying basis for the `ConsoleDispatcher` is the [Faraday](https://github.com/lostisland/faraday) library. A `Faraday::Connection` object should be utilized, probably as a `@connection` object defined as an `attr_accessor` for any other new httpdispatchers.
+
+An `HttpDispatcher` should include modules representing the products/services and a mechanism for changing the versions of the service.
+
+Method names at the service level, should, in general, not use the `@connection` object but use the methods defined in the version module; they do not necessarily need to be representative of the endpoints of the service.
+
+Method names defined in the version module should be representative of the endpoints of the service.
+
+```
+├── classifier
+│   └── v1
+│       └── v1.rb
+├── classifier.rb
+├── consoledispatcher.rb
+├── rbac
+│   └── v1
+│       ├── directory_service.rb
+│       └── v1.rb
+└── rbac.rb
+```
+
+#### Why Faraday and not HTTParty?
+
+Faraday was designed with the concept of middleware–classes that you can add to your connection stack to act on requests and responses. That middleware stack has proven to be very valuable for dealing with redundant methods for dealing with API calls, while still retaining much of the versatility that HTTParty had. Faraday's middleware also allows for easy inclusion of other independent libraries, such as the Faraday cookie jar that the ConsoleDispatcher uses for its default connection.
+
+### Console Dispatcher
+
+The `ConsoleDispatcher` is designed to speak to any of the services packaged up in pe-console-services: Node Classifer, RBAC, and Activity Service. Beyond those services, the Console Dispatcher also handles connecting to the /auth endpoints, handling sessions and the CSRF token if necessary.
+
+#### Certificate Dispatcher
+
+``` ruby
+require 'scooter'
+
+#example beaker config
+#HOSTS:
+#  ubuntu1404:
+#    vmname: ubuntu-1404
+#    roles:
+#      - master
+#      - agent
+#      - database
+#      - dashboard
+#    platform: ubuntu-14.04-amd64
+
+certificate_dispatcher = Scooter::HttpDispatchers::ConsoleDispatcher.new(dashboard)
+```
+
+A `ConsoleDispatcher` assumes it is a certificate dispatcher if no credentials are passed in during initialization. As a certificate dispatcher, you do not need to maintain a session or signin. Once created, a certificate dispatcher talks directly to the services, defined by the dashboard object passed in.
+
+#### Credential Dispatcher
+
+``` ruby
+require 'scooter'
+
+#example beaker config
+#HOSTS:
+#  ubuntu1404:
+#    vmname: ubuntu-1404
+#    roles:
+#      - master
+#      - agent
+#      - database
+#      - dashboard
+#    platform: ubuntu-14.04-amd64
+
+
+certificate_dispatcher = Scooter::HttpDispatchers::ConsoleDispatcher.new(dashboard,
+    login: 'admin',
+    password: 'password')
+```
+
+A `ConsoleDispatcher` assumes it is a credential dispatcher if credentials–login and password–are passed in as parameters during creation. As a credential dispatcher, you will need to successfully signin to get a session to make further successful calls to any of the services.


### PR DESCRIPTION
![](http://www.writethedocs.org/img/2015/site-logo.png)

This commit brings in the confluence documentation for Scooter into the
`README.md`, and creates a new `docs/` folder for some of the class-level
documentation.
- https://confluence.puppetlabs.com/display/QA/Scooter
- https://confluence.puppetlabs.com/display/QA/Scooter:+HttpDispatchers:+ConsoleDispatcher
- https://confluence.puppetlabs.com/display/QA/Scooter:+HttpDispatchers

/cc @objectverbobject @ericwilliamson @doug-rosser @anodelman 
