### PR TITLE
(maint) Fix optional arguments for ruby 2.2

### DIFF
--- a/lib/scooter/ldap.rb
+++ b/lib/scooter/ldap.rb
@@ -150,7 +150,7 @@ module Scooter
         end
       end
 
-      def create_ds_user(attributes, users_dn=users_dn)
+      def create_ds_user(attributes, users_dn=self.users_dn)
         default_attributes = {:objectClass => ['top',
                                                'person',
                                                'organizationalPerson',
@@ -171,7 +171,7 @@ module Scooter
         end
       end
 
-      def create_ds_group(attributes, groups_dn=groups_dn)
+      def create_ds_group(attributes, groups_dn=self.groups_dn)
 
         #When Openldap, you must specify :member entries in the attributes
         default_attributes = {:objectClass => ["top", "groupOfUniqueNames"]}


### PR DESCRIPTION
As of ruby 2.2 it's no longer possible to assign a default value in an
argument from an outer scope method of the same name.

e.g.

``` ruby
def foo
  10
end

def bar(foo=foo)
  puts foo
end
```

In ruby 2.1 this prints 10, in ruby 2.2 a blank line as foo is nil.
