### PR TITLE
(maint) fix bad version number

### DIFF
--- a/lib/scooter/version.rb
+++ b/lib/scooter/version.rb
@@ -1,5 +1,5 @@
 module Scooter
   module Version
-    STRING = '2.2'
+    STRING = '2.2.0'
   end
 end


### PR DESCRIPTION
Tony accidently pushed 2.2 instead of 2.2.0 to the internal mirror; this
commit just fixes the bump so that the release pipeline doesn't break
when trying to parse the 2.2 version.
