### PR TITLE
(QA-1937) Create base httpdispatcher

### DIFF
--- a/lib/scooter/httpdispatchers.rb
+++ b/lib/scooter/httpdispatchers.rb
@@ -1,4 +1,4 @@
-%w( consoledispatcher ).each do |lib|
+%w( httpdispatcher consoledispatcher ).each do |lib|
   require "scooter/httpdispatchers/#{lib}"
 end
 

--- a/lib/scooter/httpdispatchers/httpdispatcher.rb
+++ b/lib/scooter/httpdispatchers/httpdispatcher.rb
@@ -1,0 +1,145 @@
+module Scooter
+  module HttpDispatchers
+
+    # <i>HttpDispatcher</i> is the base class to extend when constructing
+    # service specific objects. It contains specific logic to extract out
+    # certificates from Beaker hosts provided as the host argument.
+    # You can directly instantiate from this class if you would like only this
+    # low level functionality. Otherwise, the primary function of this class
+    # is to allow more specific Dispatchers, such as the ConsoleDispatcher, to
+    # extend it and write higher level functionality.
+    class HttpDispatcher
+
+      attr_accessor :connection, :host, :ssl
+      # The only required parameter for the HttpDispatcher is the host, which
+      # could either be a beaker Unix::Host or a String. HttpDispatchers offer
+      # support for automatically generating the required SSL components for the
+      # Dispatcher if it is passed a Unix Host.
+      #
+      # If it is only passed a String, than it is up to the caller to correctly
+      # configure the connection object to be configured correctly. Support for
+      # Strings is experimental for now; it may be deprecated if there is no
+      # feedback indicating that this functionality is being used.
+      #
+      # @param host(Unix::Host) The beaker host object you wish to communicate
+      #   with.
+      def initialize(host)
+        @ssl = {}
+        @host = host
+        if @host.is_a?(Unix::Host)
+          @connection = create_default_connection_with_beaker_host
+        elsif @host.is_a?(String)
+          @connection = create_default_connection
+          set_url_prefix
+        else
+          raise "Argument host must be Unix::Host or String"
+        end
+      end
+
+      def initialize_connection
+        if @host.is_a?(Unix::Host)
+          @connection = create_default_connection_with_beaker_host
+        elsif @host.is_a?(String)
+          @connection = create_default_connection
+          set_url_prefix
+          add_ssl_components_to_connection
+        else
+          raise "Argument host must be Unix::Host or String"
+        end
+
+      end
+      def create_default_connection
+        Faraday.new do |conn|
+          conn.request :json
+
+          # This logger will need to be configurable somehow..., maybe based on
+          # beaker log-level?
+          conn.response :follow_redirects
+          conn.response :json, :content_type => /\bjson$/
+          conn.response :raise_error
+          conn.response :logger, nil, bodies: true
+
+          conn.use :cookie_jar
+
+          conn.adapter :net_http
+        end
+      end
+
+      def set_url_prefix(connection=self.connection)
+        if host.is_a?(Unix::Host)
+          connection.url_prefix.host = is_resolvable ? host.hostname : Scooter::Utilities::BeakerUtilities.get_public_ip(host)
+        else
+          connection.url_prefix.host = host
+        end
+      end
+
+      def create_default_connection_with_beaker_host
+        connection = create_default_connection
+        set_url_prefix(connection)
+        acquire_ssl_components if ssl.empty?
+        add_ssl_components_to_connection(connection)
+        connection
+      end
+
+      # See if we can reach the host by hostname
+      def is_resolvable(host=self.host)
+        begin
+          Resolv.getaddress(host.hostname)
+          true
+        rescue Resolv::ResolvError
+          false
+        end
+      end
+
+      # If you would like to run tests that expect 400 or even 500 responses,
+      # apply this method to remove the <tt>:raise_error</tt> middleware.
+      def remove_error_checking(connection=self.connection)
+        connection.builder.delete(Faraday::Response::RaiseError)
+      end
+
+      def acquire_ssl_components(host=self.host)
+        if !host.is_a?(Unix::Host)
+          raise 'Can only acquire SSL certs if the host is a Unix::Host'
+        end
+        acquire_ca_cert(host)
+        acquire_cert_and_key(host)
+      end
+
+      def acquire_ca_cert(host=self.host)
+        @ssl['ca_file'] = Scooter::Utilities::BeakerUtilities.pe_ca_cert_file(host)
+      end
+
+      def acquire_cert_and_key(host=self.host)
+        client_key = Scooter::Utilities::BeakerUtilities.pe_private_key(host)
+        client_cert = Scooter::Utilities::BeakerUtilities.pe_hostcert(host)
+        @ssl['client_key']  = OpenSSL::PKey.read(client_key)
+        @ssl['client_cert'] = OpenSSL::X509::Certificate.new(client_cert)
+      end
+
+      def add_ssl_components_to_connection(connection=self.connection)
+        # return immediately if the ssl object is empty
+        if ssl.empty?
+          warn 'no ssl keys defined, the connection object will not be modified'
+          return
+        end
+        # enforce the scheme to be https, since we are adding ssl components to
+        # the connection object
+        connection.url_prefix.scheme = 'https'
+
+        @ssl.each do |k, v|
+          connection.ssl[k] = v
+        end
+
+        if host.is_a?(Unix::Host)
+          if connection.url_prefix.host == Scooter::Utilities::BeakerUtilities.get_public_ip(host) && connection.ssl['verify'] == nil
+            # Because we are connecting to the dashboard by IP address, SSL verification
+            # against the CA will fail. Disable verifying against it for now until a better
+            # fix can be found.
+            connection.ssl['verify'] = false
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -32,7 +32,7 @@ module Scooter
 
         response = create_local_user(user_hash)
         return response if response.env.status != 200
-        Scooter::HttpDispatchers::ConsoleDispatcher.new(@dashboard,
+        Scooter::HttpDispatchers::ConsoleDispatcher.new(@host,
                                                         login: login,
                                                         password: password)
       end

--- a/lib/scooter/httpdispatchers/rbac/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/rbac/v1/v1.rb
@@ -46,7 +46,7 @@ module Scooter
         # a temporary connection that doesn't use that particular middleware.
         def create_password_reset_token(uuid)
           old_connection = @connection
-          @connection = create_default_connection_and_initialize
+          @connection = initialize_connection
           @connection.builder.delete(FaradayMiddleware::ParseJson)
           signin if !is_certificate_dispatcher?
           set_rbac_path

--- a/spec/scooter/httpdispatchers/httpdispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/httpdispatcher_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+
+module Scooter
+
+  describe HttpDispatchers::HttpDispatcher do
+
+    let(:host) {double('host')}
+
+    subject { HttpDispatchers::HttpDispatcher.new(host) }
+
+
+    context 'with a beaker host passed in' do
+      unixhost = { roles:     ['test_role'],
+                   'platform' => 'debian-7-x86_64' }
+      let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
+
+      before do
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:pe_ca_cert_file).and_return('cert file')
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:pe_private_key).and_return('key file')
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:pe_hostcert).and_return('host cert')
+        expect(OpenSSL::PKey).to receive(:read).and_return('Pkey')
+        expect(OpenSSL::X509::Certificate).to receive(:new).and_return('client_cert')
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
+        expect(subject).not_to be_nil
+
+      end
+
+      it 'sets the hostname correctly' do
+        expect(subject.connection.url_prefix.hostname).to eq('test.com')
+      end
+
+      it 'automatically has been configured for https' do
+        expect(subject.connection.url_prefix.scheme).to eq('https')
+      end
+
+      it 'automatically has a defined CA file' do
+        expect(subject.connection.ssl['ca_file']).to eq('cert file')
+      end
+
+      it 'automatically has a defined client key' do
+        expect(subject.connection.ssl['client_key']).to eq('Pkey')
+      end
+
+      it 'automatically has a defined client cert' do
+        expect(subject.connection.ssl['client_cert']).to eq('client_cert')
+      end
+
+    end
+
+    context 'with a string passed in for initialization' do
+      let(:host) {'test.com'}
+      before do
+        expect(subject).not_to be_nil
+      end
+
+      it 'sets the hostname correctly for the dispatcher object' do
+        expect(subject.connection.url_prefix.host).to eq('test.com')
+
+      end
+
+      it 'does not set ssl when there are no ssl components to add' do
+        expect(subject.add_ssl_components_to_connection).to eq(nil)
+        expect(subject.connection.url_prefix.scheme).to eq('http')
+        expect(subject.connection.ssl['client_key']).to eq(nil)
+        expect(subject.connection.ssl['client_cert']).to eq(nil)
+        expect(subject.connection.ssl['ca_file']).to eq(nil)
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require 'scooter'
-
 RSpec.configure do |c|
 
 end


### PR DESCRIPTION
Prior to this commit, the only real dispatcher available was the
consoledispatcher. The consoledispatcher had much of the base methods
defined in itself, which needed to be pulled out and put into another
class that all other dispatcher classes should be subclassing. This PR
creates a base httpdispatcher, making it more straightfoward to
subclass the httpdispatcher class and build different dispatching
objects.
