### PR TITLE
(QA-1943) Add method for ou's created during old init

### DIFF
--- a/lib/scooter/ldap.rb
+++ b/lib/scooter/ldap.rb
@@ -195,14 +195,18 @@ module Scooter
         end
       end
 
+      def create_ou_for_users_and_groups
+        @users_dn = create_temp_ou('users')
+        @groups_dn = create_temp_ou('groups')
+      end
+
       # This is the primary method most tests will use. It creates two
       # organizational units, or ou's, to base all your testing around. There is
       # one ou for groups and one for users. Most testing can be covered by
       # simply running the method <tt>create_default_test_groups_and_users</tt>.
       def create_default_test_groups_and_users
 
-        @users_dn = create_temp_ou('users')
-        @groups_dn = create_temp_ou('groups')
+        create_ou_for_users_and_groups
 
         create_default_users
 


### PR DESCRIPTION
A previous commit moved the organizational unit creation from the init
to the base method to generate a test environment of users and groups
for RBAC; this broke any implementation not using that method to
generate a test environment.

This doesn't add that back, as putting this action in the init was a
mistake; it does, however, give the user the ability to create the ou's
independently, and set the instance variables accordingly.
