### PR TITLE
(QA-1969) Add token support to Scooter

### DIFF
--- a/lib/scooter/httpdispatchers/activity.rb
+++ b/lib/scooter/httpdispatchers/activity.rb
@@ -1,0 +1,21 @@
+%w( v1 ).each do |lib|
+  require "scooter/httpdispatchers/activity/v1/#{lib}"
+end
+
+module Scooter
+  module HttpDispatchers
+    module Activity
+     include Scooter::HttpDispatchers::Activity::V1
+
+     def set_activity_service_path(connection=self.connection)
+       set_url_prefix
+       if is_certificate_dispatcher? || has_token?
+         connection.url_prefix.path = '/activity-api'
+       else
+         connection.url_prefix.path = '/rbac/activity-api'
+       end
+     end
+
+    end
+  end
+end

--- a/lib/scooter/httpdispatchers/activity/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/activity/v1/v1.rb
@@ -1,0 +1,12 @@
+module Scooter
+  module HttpDispatchers
+    module Activity
+      # Methods here are generally representative of endpoints, and depending
+      # on the method, return either a Faraday response object or some sort of
+      # instance of the object created/modified.
+      module V1
+
+      end
+    end
+  end
+end

--- a/lib/scooter/httpdispatchers/classifier.rb
+++ b/lib/scooter/httpdispatchers/classifier.rb
@@ -17,6 +17,15 @@ module Scooter
       include Scooter::Utilities
       Rootuuid = '00000000-0000-4000-8000-000000000000'
 
+      def set_classifier_path(connection=self.connection)
+        set_url_prefix
+        if is_certificate_dispatcher? || has_token?
+          connection.url_prefix.path = '/classifier-api'
+        else
+          connection.url_prefix.path = '/api/classifier/service/'
+        end
+      end
+
       # This returns a tree-like hash of all node groups in the classifier; each
       # key is a uuid, each value is an array of direct children. If no direct
       # children are found, the value is an empty array. This representation
@@ -116,6 +125,8 @@ module Scooter
 
         create_node_group(hash).env.body
       end
+
+      alias_method :generate_node_group, :create_new_node_group_model
 
       # This takes an optional hash of node group parameters. If a "name" option
       # is provided it will attempt to find an existing node group with that

--- a/lib/scooter/httpdispatchers/httpdispatcher.rb
+++ b/lib/scooter/httpdispatchers/httpdispatcher.rb
@@ -1,6 +1,8 @@
 module Scooter
   module HttpDispatchers
 
+    require 'scooter/middleware/rbac_auth_token'
+
     # <i>HttpDispatcher</i> is the base class to extend when constructing
     # service specific objects. It contains specific logic to extract out
     # certificates from Beaker hosts provided as the host argument.

--- a/lib/scooter/httpdispatchers/rbac/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/rbac/v1/v1.rb
@@ -79,6 +79,29 @@ module Scooter
           end
         end
 
+        def replace_role(role)
+          set_rbac_path
+          @connection.put("v1/roles/#{role['id']}") do |request|
+            request.body = role
+          end
+        end
+
+        def acquire_token(login, password)
+          # set the token to true to correctly set the url_prefix
+          @token = true
+          set_rbac_path
+
+          # set this back to nil in case the call fails
+          @token = nil
+          response = @connection.post "v1/auth/token" do |request|
+            creds= {}
+            creds[:login] = login
+            creds[:password] = password
+            request.body = creds
+          end
+          response.env.body['token']
+        end
+
       end
     end
   end

--- a/lib/scooter/middleware/rbac_auth_token.rb
+++ b/lib/scooter/middleware/rbac_auth_token.rb
@@ -1,0 +1,35 @@
+module Faraday
+  # This middleware checks for tokens and adds them to the request when found.
+  # To include this correctly, you will need to pass the dispatcher itself to
+  # the initialize method so it can read if the dispatcher has tokens or not.
+  # Beyond just the token itself, it also checks the dispatcher if the
+  # instance variable <i>send_auth_token_as_query_param</i> is set to true.
+  # Otherwise, it will always attach it as an X-Authentication header.
+  class RbacAuthToken < Faraday::Middleware
+    attr_reader :dispatcher
+
+
+    # @param app() Structural requirement for Faraday::Middleware initialization
+    # @param dispatcher(Scooter::HttpDispatchers::ConsoleDispatcher required)
+    #   Required param so that the middleware can check to see if there is a
+    #   token set in the implementing dispatcher class. Will work with
+    #   <i>ConsoleDispatcher</i>.
+    def initialize(app, dispatcher)
+      super(app)
+      @dispatcher = dispatcher
+    end
+
+    def call(env)
+      if dispatcher.token && dispatcher.send_auth_token_as_query_param
+        query_array = [['token', dispatcher.token]]
+        URI.decode_www_form(env.url.query).each {|tuple| query_array << tuple} if env.url.query
+        env.url.query = URI.encode_www_form(query_array)
+      elsif dispatcher.token
+        env.request_headers['X-Authentication'] = dispatcher.token
+      end
+      @app.call env
+    end
+  end
+end
+
+Faraday::Request.register_middleware :rbac_auth_token => lambda { Faraday::RbacAuthToken }

--- a/spec/scooter/httpdispatchers/middleware/rbac_auth_token_spec.rb
+++ b/spec/scooter/httpdispatchers/middleware/rbac_auth_token_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Faraday::RbacAuthToken do
+
+  let(:conn) { Faraday.new(:url => 'http://test.com/path') }
+  let(:dispatcher) { double('dispatcher') }
+
+  before do
+    conn.builder.insert(0, Faraday::RbacAuthToken, dispatcher)
+    conn.adapter :test do |stub|
+      stub.get('/path') {[200, {}, 'success']}
+    end
+  end
+
+  describe 'a dispatcher with no token' do
+    before do
+      allow(dispatcher).to receive(:token) { nil }
+      allow(dispatcher).to receive(:send_auth_token_as_query_param) { nil }
+    end
+    it 'sends the request without a token' do
+      expect(conn.get.env.url.query).to eq(nil)
+      expect(conn.get.env.request_headers['X-Authentication']).to eq(nil)
+      expect{conn.get}.not_to raise_error
+    end
+  end
+
+  describe 'a dispatcher with a token' do
+    before do
+      allow(dispatcher).to receive(:token) {'testingtoken'}
+      allow(dispatcher).to receive(:send_auth_token_as_query_param) { nil }
+    end
+    it 'sends the request with the token in an X-Authentication header' do
+      expect(conn.get.env.request_headers['X-Authentication']).to eq('testingtoken')
+    end
+  end
+
+  describe 'a dispatcher with a token as a query param' do
+    before do
+      allow(dispatcher).to receive(:token) { 'testingtoken' }
+      allow(dispatcher).to receive(:send_auth_token_as_query_param) { true }
+    end
+    it 'sends the request with the token as a query param' do
+      expect(conn.get.env.url.query).to eq('token=testingtoken')
+    end
+  end
+
+  describe 'a dispatcher with a token to be sent as a query param does not overwrite other params' do
+    before do
+      allow(dispatcher).to receive(:token) { 'testingtoken' }
+      allow(dispatcher).to receive(:send_auth_token_as_query_param) { true }
+    end
+    it 'sends the request with the token and other parameters' do
+      response = conn.get {|req| req.params[:extra_param] = 'extra_value'}
+      hashed_query = CGI.parse(response.env.url.query)
+      expect(hashed_query).to eq('token'=> ['testingtoken'], 'extra_param' => ['extra_value'])
+    end
+  end
+end

--- a/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
+++ b/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+module Scooter
+
+  describe Scooter::HttpDispatchers::Rbac do
+
+    let(:host) {double('host')}
+    let(:credentials) {double('credentials')}
+
+    subject { HttpDispatchers::ConsoleDispatcher.new(host, credentials) }
+
+    context 'with a beaker host passed in' do
+
+      unixhost = { roles:     ['test_role'],
+                   'platform' => 'debian-7-x86_64' }
+      let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
+      let(:credentials) {{login: 'Ziggy', password: 'Stardust'}}
+
+      before do
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:pe_ca_cert_file).and_return('cert file')
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
+        expect(subject).not_to be_nil
+      end
+
+      describe '.acquire_token_with_credentials' do
+        before do
+          # find the index of the default Faraday::Adapter::NetHttp handler
+          # and replace it with the Test adapter
+          index = subject.connection.builder.handlers.index(Faraday::Adapter::NetHttp)
+          subject.connection.builder.swap(index, Faraday::Adapter::Test) do |stub|
+            stub.post('/rbac-api/v1/auth/token') { [200, {}, 'token' =>'blah'] }
+            end
+        end
+        it 'sets the token instance variable for the dispatcher' do
+          expect{subject.acquire_token_with_credentials}.not_to raise_error
+          expect(subject.token).to eq('blah')
+        end
+      end
+
+      describe 'ensure failure to get a token does not set the token instance variable' do
+        before do
+          # find the index of the default Faraday::Adapter::NetHttp handler
+          # and replace it with the Test adapter
+          index = subject.connection.builder.handlers.index(Faraday::Adapter::NetHttp)
+          subject.connection.builder.swap(index, Faraday::Adapter::Test) do |stub|
+            stub.post('/rbac-api/v1/auth/token') { [401, {}, 'unauthorized'] }
+          end
+        end
+        it 'the token variable should still be nil for a failed request' do
+          expect{subject.acquire_token_with_credentials}.to raise_error(Faraday::ClientError)
+          expect(subject.token).to eq(nil)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
In Ankeny, RBAC now supports acquiring tokens through a new endpoint
provided by RBAC. This PR extends the RBAC modules and
ConsoleDispatcher to allow for a new 'token' instance variable that can
be set; if the token is set, console dispatchers will attempt to use it
in the request and set the correct routes, directly to the API.
