### PR TITLE
(QA-1980) Remove routes to pe-console-middlware proxies

### DIFF
--- a/lib/scooter/httpdispatchers/activity.rb
+++ b/lib/scooter/httpdispatchers/activity.rb
@@ -8,12 +8,7 @@ module Scooter
      include Scooter::HttpDispatchers::Activity::V1
 
      def set_activity_service_path(connection=self.connection)
-       set_url_prefix
-       if is_certificate_dispatcher? || has_token?
          connection.url_prefix.path = '/activity-api'
-       else
-         connection.url_prefix.path = '/rbac/activity-api'
-       end
      end
 
     end

--- a/lib/scooter/httpdispatchers/classifier.rb
+++ b/lib/scooter/httpdispatchers/classifier.rb
@@ -19,11 +19,7 @@ module Scooter
 
       def set_classifier_path(connection=self.connection)
         set_url_prefix
-        if is_certificate_dispatcher? || has_token?
-          connection.url_prefix.path = '/classifier-api'
-        else
-          connection.url_prefix.path = '/api/classifier/service/'
-        end
+        connection.url_prefix.path = '/classifier-api'
       end
 
       # This returns a tree-like hash of all node groups in the classifier; each

--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -19,11 +19,7 @@ module Scooter
 
       def set_rbac_path(connection=self.connection)
         set_url_prefix
-        if is_certificate_dispatcher? || has_token?
-          connection.url_prefix.path = '/rbac-api'
-        else
-          connection.url_prefix.path = '/api/rbac/service/'
-        end
+        connection.url_prefix.path = '/rbac-api'
       end
 
       def generate_local_user(options = {})
@@ -77,9 +73,7 @@ module Scooter
       end
 
       def get_user_id_of_console_dispatcher(console_dispatcher)
-        if console_dispatcher.is_certificate_dispatcher?
-          return get_user_id_by_login_name('api_user')
-        end
+        return get_user_id_by_login_name('api_user') if console_dispatcher.credentials == nil
         get_user_id_by_login_name(console_dispatcher.credentials.login)
       end
 
@@ -140,6 +134,12 @@ module Scooter
           return role['id'] if role['display_name'] == role_name
         end
         nil #return nil if role_name not found
+      end
+
+      def reset_console_dispatcher_password(console_dispatcher, password)
+        token = get_password_reset_token_for_console_dispatcher(console_dispatcher)
+        reset_local_user_password(token, password)
+        console_dispatcher.credentials.password = password
       end
 
       def reset_console_dispatcher_password_to_default(console_dispatcher)

--- a/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+module Scooter
+
+  describe HttpDispatchers::ConsoleDispatcher do
+
+    let(:host) {double('host')}
+    let(:credentials) { { login: username, password: password} }
+    let(:username) {'Ziggy'}
+    let(:password) {'Stardust'}
+    let(:mock_page) {double('mock_page')}
+
+    subject { HttpDispatchers::ConsoleDispatcher.new(host, credentials) }
+
+    context 'with a beaker host passed in' do
+      unixhost = { roles:     ['test_role'],
+                   'platform' => 'debian-7-x86_64' }
+      let(:host) { Beaker::Host.create('test.com', unixhost, {}) }
+      before do
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:pe_ca_cert_file).and_return('cert file')
+        expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
+        expect(subject).not_to be_nil
+      end
+
+      context '.signin with a page that returns an xcsrf token' do
+        let(:mock_page) { <<-XCSRF_PAGE
+            <!doctype html>
+              <head>
+                <meta name="__anti-forgery-token" content="xcsrf-token" />
+              </head>
+            </html>
+        XCSRF_PAGE
+        }
+        before do
+          index = subject.connection.builder.handlers.index(Faraday::Adapter::NetHttp)
+          subject.connection.builder.swap(index, Faraday::Adapter::Test) do |stub|
+            stub.post('/auth/login', "username=#{username}&password=#{password}") {[200, {}, '']}
+            stub.get('/') {[200, {}, mock_page]}
+          end
+        end
+
+        it 'sends the credentials' do
+          expect{subject.signin}.to_not raise_error
+        end
+
+        it 'sets the xcsrf token in the header' do
+          subject.signin
+          expect(subject.connection.headers['X-CSRF-Token']).to eq('xcsrf-token')
+        end
+      end
+
+      context '.signin with a page that has no xcsrf token' do
+        let(:mock_page) { <<-XCSRF_PAGE
+            <!doctype html>
+              <head>
+              </head>
+            </html>
+        XCSRF_PAGE
+        }
+        before do
+          index = subject.connection.builder.handlers.index(Faraday::Adapter::NetHttp)
+          subject.connection.builder.swap(index, Faraday::Adapter::Test) do |stub|
+            stub.post('/auth/login', "username=#{username}&password=#{password}") {[200, {}, '']}
+            stub.get('/') {[200, {}, mock_page]}
+          end
+        end
+
+        it 'does not raise an error' do
+          expect{subject.signin}.to_not raise_error
+        end
+
+        it 'There is no xcsrf token set' do
+          subject.signin
+          expect(subject.connection.headers['X-CSRF-Token']).to eq(nil)
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
Now that the routes have been relaxed in Ankeny, we can send all traffic
to the services directly and not rely on the pe-console-middleware to
proxy web sessions.
