### PR TITLE
Add optional expiry parameter to token acquisition

### DIFF
--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -153,8 +153,8 @@ module Scooter
         create_password_reset_token(uuid)
       end
 
-      def acquire_token_with_credentials
-        @token = acquire_token(credentials.login, credentials.password)
+      def acquire_token_with_credentials(expiry=nil)
+        @token = acquire_token(credentials.login, credentials.password, expiry)
       end
     end
   end

--- a/lib/scooter/httpdispatchers/rbac/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/rbac/v1/v1.rb
@@ -85,12 +85,13 @@ module Scooter
           end
         end
 
-        def acquire_token(login, password)
+        def acquire_token(login, password, expiry=nil)
           set_rbac_path
           response = @connection.post "v1/auth/token" do |request|
             creds= {}
             creds[:login] = login
             creds[:password] = password
+            creds[:expiry] = expiry if expiry
             request.body = creds
           end
           response.env.body['token']

--- a/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
+++ b/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
@@ -35,6 +35,10 @@ module Scooter
           expect{subject.acquire_token_with_credentials}.not_to raise_error
           expect(subject.token).to eq('blah')
         end
+        it 'accepts an optional expiry parameter' do
+          expect{subject.acquire_token_with_credentials('600')}.not_to raise_error
+          expect(subject.token).to eq('blah')
+        end
       end
 
       describe 'ensure failure to get a token does not set the token instance variable' do


### PR DESCRIPTION
The RBAC auth token endpoint now takes an optional expiry parameter;
this change allows for that paramter to be exposed by the relevant rbac
and v1 methods.
