### PR TITLE
(PE-12084) Ensure URIs are subclassed from URI::HTTPS

### DIFF
--- a/lib/scooter/httpdispatchers/httpdispatcher.rb
+++ b/lib/scooter/httpdispatchers/httpdispatcher.rb
@@ -38,6 +38,12 @@ module Scooter
         else
           raise "Argument host must be Unix::Host or String"
         end
+        # The http-cookie library that the cookie-jar wraps requires that a
+        # URI object be specifically a URI::HTTPS object. This changes the
+        # default url_prefix in Faraday to be sub-classed from HTTPS, not plain
+        # old HTTP. This should have no effect on any other middleware, as HTTPS
+        # is just HTTP subclassed with different defaults.
+        @connection.url_prefix = URI.parse(@connection.url_prefix.to_s)
       end
 
       def initialize_connection

--- a/spec/scooter/httpdispatchers/httpdispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/httpdispatcher_spec.rb
@@ -45,6 +45,10 @@ module Scooter
         expect(subject.connection.ssl['client_cert']).to eq('client_cert')
       end
 
+      it 'has a URI::HTTPS object for a url_prefix' do
+        expect(subject.connection.url_prefix).to be_an_instance_of(URI::HTTPS)
+      end
+
       context 'when it receives a 500 error' do
         before do
           index = subject.connection.builder.handlers.index(Faraday::Adapter::NetHttp)


### PR DESCRIPTION
The http-cookie library used by faraday cookie-jar relies on the ancient
text of http-cookie, which has not received an update for over two
years. That cookie library erroneously demanded that all URIs must be
subclassed from URI::HTTPS, not accepting a URI::HTTP object with a
scheme set to https. This change hardcodes all the httpdispatchers to
use URI::HTTPS objects for the url_prefix. This should have zero effect
on other middleware, as URI::HTTPS is just a subclass of URI::HTTP.
