### PR TITLE
(maint) Add functionality to find rbac groups by name

### DIFF
--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -112,6 +112,14 @@ module Scooter
         delete_local_user(uuid)
       end
 
+      def get_group_data_by_name(name)
+        groups = get_list_of_groups
+        groups.each do |group|
+          return group if name == group['login']
+        end
+        nil #return nil if name is not found
+      end
+
       def get_group_id(group_name)
         groups = get_list_of_groups
         groups.each do |group|

--- a/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
+++ b/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
@@ -56,6 +56,38 @@ module Scooter
         end
       end
 
+      describe '.get_group_data_by_name' do
+        let(:groups_array) {
+          [{"user_ids"=>[],
+            "role_ids"=>[],
+            "display_name"=>"",
+            "is_superuser"=>false,
+            "is_remote"=>true,
+            "is_group"=>true,
+            "login"=>"group1",
+            "id"=>"09c2c1fd-ea01-4555-bc7b-a8f25c4511f8"},
+           {"user_ids"=>[],
+             "role_ids"=>[],
+             "display_name"=>"",
+             "is_superuser"=>false,
+             "is_remote"=>true,
+             "is_group"=>true,
+             "login"=>"group2",
+             "id"=>"09c2c1fd-ea01-4555-bc7b-a8f25c4511f7"}]
+        }
+        before do
+          expect(subject).to receive(:get_list_of_groups) { groups_array }
+        end
+        it 'can find group1 in the payload' do
+          expect(subject.get_group_data_by_name('group1')).to eq(groups_array[0])
+        end
+        it 'can find group2 in the payload' do
+          expect(subject.get_group_data_by_name('group2')).to eq(groups_array[1])
+        end
+        it 'returns nil for group3, who is not in the payload' do
+          expect(subject.get_group_data_by_name('group3')).to eq(nil)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This change allows for simple retrieval of an rbac group's status based
on the 'login' or name of the group.
