### PR TITLE
(QENG-3460) Add upper bound for net-ldap dependency

### DIFF
--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   #Run time dependencies
   spec.add_runtime_dependency 'json', '~> 1.8'
-  spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1'
+  spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1', '<= 0.12.1'
   spec.add_runtime_dependency 'beaker', '~> 2.1', '>= 2.1.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'


### PR DESCRIPTION
New versions of the net-ldap gem, after version 0.12.1, require ruby 2.0
or greater. This PR adds that version as the upper bound for scooter, so
it can run on ruby 1.9.3 systems.
