### PR TITLE
(maint) avoid login collisions by using more random characters

### DIFF
--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -23,9 +23,9 @@ module Scooter
       end
 
       def generate_local_user(options = {})
-        email = options['email'] || "#{RandomString.generate(4)}@example.com"
-        display_name = options['display_name'] || RandomString.generate(4)
-        login = options['login'] || RandomString.generate(4)
+        email = options['email'] || "#{RandomString.generate(8)}@example.com"
+        display_name = options['display_name'] || RandomString.generate(8)
+        login = options['login'] || RandomString.generate(16)
         role_ids = options['role_ids'] || []
         password = options['password'] || 'Puppet11'
 


### PR DESCRIPTION
Occasionally the rbac integration tests are failing because the db is not cleared out between tests and the random number generator sometimes creates the same result. Attempts to create duplicate local users causes unexpected failures.

Change the number of characters used for display name, email and login to be larger to attempt to avoid collisions.  The display name and email aren't strictly necessary, but seem like a good idea.
