### PR TITLE
(maint) Fix comparison methods since replica has different certs

### DIFF
--- a/lib/scooter/httpdispatchers/activity.rb
+++ b/lib/scooter/httpdispatchers/activity.rb
@@ -19,12 +19,12 @@ module Scooter
         original_host_name = self.host
         begin
           self.host = host_name.to_s
-          set_url_prefix
+          initialize_connection
           other_rbac_events       = get_rbac_events.env.body
           other_classifier_events = get_classifier_events.env.body
         ensure
           self.host = original_host_name
-          set_url_prefix
+          initialize_connection
         end
 
         self_rbac_events       = get_rbac_events.env.body

--- a/lib/scooter/httpdispatchers/classifier.rb
+++ b/lib/scooter/httpdispatchers/classifier.rb
@@ -305,14 +305,14 @@ module Scooter
         original_host_name = self.host
         begin
           self.host = host_name.to_s
-          set_url_prefix
+          initialize_connection
           other_nodes        = get_list_of_nodes
           other_classes      = get_list_of_classes
           other_environments = get_list_of_environments
           other_groups       = get_list_of_node_groups
         ensure
           self.host = original_host_name
-          set_url_prefix
+          initialize_connection
         end
 
         self_nodes        = get_list_of_nodes

--- a/lib/scooter/httpdispatchers/consoledispatcher.rb
+++ b/lib/scooter/httpdispatchers/consoledispatcher.rb
@@ -60,10 +60,10 @@ module Scooter
       #
       # @param credentials(Hash optional) Provide credentials if you wish to
       #   communicate through the UI proxy.
-      def initialize(host, credentials=nil)
+      def initialize(host, credentials=nil, log_level=Logger::DEBUG, log_body=true)
         @credentials = Credentials.new(credentials[:login],
                                        credentials[:password]) if credentials
-        super(host)
+        super(host, log_level, log_body)
       end
 
       def set_url_prefix(connection=self.connection)

--- a/lib/scooter/httpdispatchers/puppetdbdispatcher.rb
+++ b/lib/scooter/httpdispatchers/puppetdbdispatcher.rb
@@ -20,12 +20,14 @@ module Scooter
         original_host_name = self.host
         begin
           self.host = host_name
+          initialize_connection
           other_nodes = query_nodes.body
           other_catalogs = query_catalogs.body
           other_facts = query_facts.body
           other_reports = query_reports.body
         ensure
           self.host = original_host_name
+          initialize_connection
         end
 
         self_nodes = query_nodes.body
@@ -66,7 +68,6 @@ module Scooter
       def node_match?(other_node, self_node)
         result = other_node['certname'] == self_node['certname'] && other_node['facts_timestamp'] == self_node['facts_timestamp'] &&
             other_node['report_timestamp'] == self_node['report_timestamp'] && other_node['catalog_timestamp'] == self_node['catalog_timestamp']
-        @faraday_logger.debug("Node does not match - self_node: #{self_node}, other_node: #{other_node}") unless result
         result
       end
       private :node_match?
@@ -88,7 +89,6 @@ module Scooter
       # @return [Boolean]
       def catalog_match?(other_catalog, self_catalog)
         result = other_catalog['catalog_uuid'] == self_catalog['catalog_uuid'] && other_catalog['producer_timestamp'] == self_catalog['producer_timestamp']
-        @faraday_logger.debug("catalog does not match - self_catalog: #{self_catalog}, other_catalog: #{other_catalog}")
         result
       end
       private :catalog_match?
@@ -102,7 +102,6 @@ module Scooter
         return false unless other_facts.size == self_facts.size
         other_facts.each_index do |index|
           unless other_facts[index] == self_facts[index]
-            @faraday_logger.debug("fact does not match - self_fact: #{self_facts[index]}, other_fact: #{other_facts[index]}")
             return false
           end
         end
@@ -126,7 +125,6 @@ module Scooter
       # @return [Boolean]
       def report_match?(other_report, self_report)
         result = other_report['hash'] == self_report['hash'] && other_report['producer_timestamp'] == self_report['producer_timestamp']
-        @faraday_logger.debug("report does not match - self_report: #{self_report}, other_report: #{other_report}")
         result
       end
       private :report_match?

--- a/lib/scooter/httpdispatchers/rbac.rb
+++ b/lib/scooter/httpdispatchers/rbac.rb
@@ -169,13 +169,13 @@ module Scooter
         original_host_name = self.host
         begin
           self.host = host_name.to_s
-          set_url_prefix
+          initialize_connection
           other_users  = get_list_of_users
           other_groups = get_list_of_groups
           other_roles  = get_list_of_roles
         ensure
           self.host = original_host_name
-          set_url_prefix
+          initialize_connection
         end
 
         self_users  = get_list_of_users

--- a/spec/scooter/httpdispatchers/activity/activity_spec.rb
+++ b/spec/scooter/httpdispatchers/activity/activity_spec.rb
@@ -200,6 +200,8 @@ module Scooter
                 [200, [], classifier_events] :
                 [200, [], classifier_events.dup["commits"].push('another_array_item')] }
           end
+          expect(subject).to receive(:create_default_connection).with(any_args).twice.and_return(subject.connection)
+          expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
         end
 
         it 'compare with self' do

--- a/spec/scooter/httpdispatchers/classifier/classifier_spec.rb
+++ b/spec/scooter/httpdispatchers/classifier/classifier_spec.rb
@@ -525,7 +525,8 @@ module Scooter
                 [200, [], class_list] :
                 [200, [], class_list.dup.push('another_array_item')] }
           end
-
+          expect(subject).to receive(:create_default_connection).with(any_args).twice.and_return(subject.connection)
+          expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
         end
         it 'compare with self' do
           expect(subject.classifier_database_matches_self?('test.com')).to be_truthy

--- a/spec/scooter/httpdispatchers/puppetdbdispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/puppetdbdispatcher_spec.rb
@@ -222,7 +222,8 @@ module Scooter
                 [200, [], [{'hash' => 'hash_value', 'producer_timestamp' => 'time'}]] :
                 [200, [], [{'hash' => 'hash_value2', 'producer_timestamp' => 'time2'}]] }
           end
-
+          expect(subject).to receive(:create_default_connection).with(any_args).twice.and_return(subject.connection)
+          expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
         end
         it 'compare with self' do
           expect(subject.database_matches_self?('test.com')).to be_truthy

--- a/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
+++ b/spec/scooter/httpdispatchers/rbac/rbac_spec.rb
@@ -336,7 +336,8 @@ module Scooter
                 [200, [], role_list] :
                 [200, [], role_list.dup.push('another_array_item')] }
           end
-
+          expect(subject).to receive(:create_default_connection).with(any_args).twice.and_return(subject.connection)
+          expect(Scooter::Utilities::BeakerUtilities).to receive(:get_public_ip).and_return('public_ip')
         end
         it 'compare with self' do
           expect(subject.rbac_database_matches_self?('test.com')).to be_truthy


### PR DESCRIPTION
Fixed comparison methods
Removed some logging
Updated log levels to match Beaker
Made log_body it's own parameter to initialize instead of trying to infer it from beaker's log level.
