### PR TITLE
(MAINT) move url prefix to orchestrator v1

### DIFF
--- a/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
@@ -6,55 +6,55 @@ module Scooter
 
         #jobs endpoints
         def get_last_jobs(n_jobs)
-          @connection.get("/v1/jobs") do |req|
+          @connection.get("v1/jobs") do |req|
             req.body = {:limit => n_jobs} if n_jobs
           end
         end
 
         def get_job(job_id)
-          @connection.get("/v1/jobs/#{job_id}")
+          @connection.get("v1/jobs/#{job_id}")
         end
 
         def get_nodes(job_id)
-          @connection.get("/v1/jobs/#{job_id}/nodes")
+          @connection.get("v1/jobs/#{job_id}/nodes")
         end
 
         def get_report(job_id)
-          @connection.get("/v1/jobs/#{job_id}/report")
+          @connection.get("v1/jobs/#{job_id}/report")
         end
 
         def get_events(job_id)
-          @connection.get("/v1/jobs/#{job_id}/events")
+          @connection.get("v1/jobs/#{job_id}/events")
         end
 
         #environments endpoints
         def get_environment(environment)
-          @connection.get("/v1/environments/#{environment}")
+          @connection.get("v1/environments/#{environment}")
         end
 
         def get_applications_in_environment(environment)
-          @connection.get("/v1/environments/#{environment}/applications")
+          @connection.get("v1/environments/#{environment}/applications")
         end
 
         def get_instances_in_environment(environment)
-          @connection.get("/v1/environments/#{environment}/instances")
+          @connection.get("v1/environments/#{environment}/instances")
         end
 
         #command endpoints
         def post_deploy(payload)
-          @connection.post("/v1/command/deploy") do |req|
+          @connection.post("v1/command/deploy") do |req|
             req.body = payload
           end
         end
 
         def post_stop(payload)
-          @connection.post("/v1/command/stop") do |req|
+          @connection.post("v1/command/stop") do |req|
             req.body = payload
           end
         end
 
         def post_plan(payload)
-          @connection.post("/v1/command/plan") do |req|
+          @connection.post("v1/command/plan") do |req|
             req.body = payload
           end
         end

--- a/lib/scooter/httpdispatchers/orchestratordispatcher.rb
+++ b/lib/scooter/httpdispatchers/orchestratordispatcher.rb
@@ -10,7 +10,7 @@ module Scooter
 
       def initialize(host)
         super(host)
-        @connection.url_prefix.path = '/orchestator'
+        @connection.url_prefix.path = '/orchestrator'
         @connection.url_prefix.port = 8143
       end
 


### PR DESCRIPTION
The `url_prefix_path` never worked.  😞 
