### PR TITLE
(maint) loosen beaker dependency

### DIFF
--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   #Run time dependencies
   spec.add_runtime_dependency 'json', '~> 1.8'
   spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1', '<= 0.12.1'
-  spec.add_runtime_dependency 'beaker', '~> 2.1', '>= 2.1.0'
+  spec.add_runtime_dependency 'beaker', '>= 2.1.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'


### PR DESCRIPTION
Now that beaker 3.0.0 is out and available, we need to loosen this
strict on the beaker major of 2.
