### PR TITLE
(maint) Properly limit jobs queries

### DIFF
--- a/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
@@ -11,8 +11,8 @@ module Scooter
 
         #jobs endpoints
         def get_last_jobs(n_jobs)
-          @connection.get("#{@version}/jobs") do |req|
-            req.body = {:limit => n_jobs} if n_jobs
+          @connection.get("#{@version}/jobs#{query_string}") do |req|
+            req.params['limit'] = n_jobs if n_jobs
           end
         end
 


### PR DESCRIPTION
The limit parameter to /jobs is expected to be sent as a query parameter
rather than as part of the body of the request.