### PR TITLE
(maint) Fix undefined variable in jobs endpoint

### DIFF
--- a/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
@@ -11,7 +11,7 @@ module Scooter
 
         #jobs endpoints
         def get_last_jobs(n_jobs)
-          @connection.get("#{@version}/jobs#{query_string}") do |req|
+          @connection.get("#{@version}/jobs") do |req|
             req.params['limit'] = n_jobs if n_jobs
           end
         end


### PR DESCRIPTION
query_string is undefined there, and was added in #94. I'm not entirely sure of what @nicklewis intended by adding it?  But it seems like it may be worth another, more fleshed out PR. For now, reverting it is easiest.