### PR TITLE
use ip by default

### DIFF
--- a/lib/scooter/httpdispatchers/httpdispatcher.rb
+++ b/lib/scooter/httpdispatchers/httpdispatcher.rb
@@ -72,7 +72,7 @@ module Scooter
         if host.is_a?(Unix::Host)
           connection.url_prefix.host = is_resolvable ? host.hostname : Scooter::Utilities::BeakerUtilities.get_public_ip(host)
         else
-          connection.url_prefix.host = host
+          connection.url_prefix.host = host.reachable_name
         end
       end
 


### PR DESCRIPTION
I was hitting the following error becasue the dashbord IP/hostname is not avalible in the host machine and therefore the farady is unable to resolve the name.  this pull ops to prefering the IP address by default

```
  puppetmaster executed in 0.01 seconds
  GET: https://puppetmaster:4433/classifier-api/v1/groups
  REQUEST HEADERS:
  User-Agent: "Faraday v0.13.1"

An error occurred while loading ./spec/acceptance/04_knot_notify_spec.rb.
Failure/Error: install_pe
NoMethodError:
  undefined method `has_key?' for nil:NilClass

# ./spec/spec_helper_acceptance.rb:66:in `<top (required)>'
# ./spec/acceptance/04_knot_notify_spec.rb:4:in `require'
# ./spec/acceptance/04_knot_notify_spec.rb:4:in `<top (required)>'
# ------------------
# --- Caused by: ---
# SocketError:
#   getaddrinfo: nodename nor servname provided, or not known
#   ./spec/spec_helper_acceptance.rb:66:in `<top (required)>'
```