### PR TITLE
(maint) add beaker-abs gem for CI.Next support

### DIFF
--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.9.12'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
+  spec.add_development_dependency 'beaker-abs, '~>0.3.0'
 
   #Documentation dependencies
   spec.add_development_dependency 'yard', '~> 0'


### PR DESCRIPTION
Required to run acceptance tests in CI.