### PR TITLE
(PE-23134) Orchestrator additions for dumplings.

### DIFF
--- a/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
@@ -104,6 +104,13 @@ module Scooter
             req.body = payload
           end
         end
+
+        #dumpling endpoints
+        def post_dumpling(payload)
+          @connection.post("#{@version}/dumplings") do |req|
+            req.body = payload
+          end
+        end
       end
     end
   end

--- a/lib/scooter/httpdispatchers/orchestratordispatcher.rb
+++ b/lib/scooter/httpdispatchers/orchestratordispatcher.rb
@@ -78,6 +78,11 @@ module Scooter
         payload = {'nodes' => node_list}
         post_inventory(payload)
       end
+
+      # @return [Faraday::Response] response object from Faraday http client
+      def create_dumpling(dumpling)
+        post_dumpling(dumpling)
+      end
     end
   end
 end

--- a/spec/scooter/httpdispatchers/orchestratordispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/orchestratordispatcher_spec.rb
@@ -241,4 +241,21 @@ describe Scooter::HttpDispatchers::OrchestratorDispatcher do
       expect(response.env.url.query).to be(nil)
     end
   end
+
+  describe '.create_dumpling' do
+    let(:dumpling) {{
+      'display-name' => 'dumplings two',
+      'tasks'         => ['echo', 'package::status'],
+      'nodes'        => ['node2']
+    }}
+
+    it {is_expected.not_to respond_to(:create_dumpling).with(0).arguments }
+    it {is_expected.to respond_to(:create_dumpling).with(1).arguments }
+    it {is_expected.not_to respond_to(:create_dumpling).with(2).arguments }
+
+    it 'should take a single dumpling object' do
+      expect(orchestrator_api.connection).to receive(:post).with("v1/dumplings")
+      expect{ orchestrator_api.create_dumpling(dumpling) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This is for the WIP endpoints for the orchestrator additions.  Once endpoint names are finalized there will be a change required, but it should be trivial.  If there's a way to add these only to the repo in which they're needed, I'd be willing to try that. @zreichert if you had time to give this a gander, I'd appreciate it, thanks!