### PR TITLE
(PE-23316) remove serial number when updating node groups

### DIFF
--- a/lib/scooter/httpdispatchers/classifier/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/classifier/v1/v1.rb
@@ -36,6 +36,7 @@ module Scooter
 
         def replace_node_group(node_group_id, node_group_model)
           set_classifier_path
+          node_group_model.delete('serial_number')
           @connection.put("v1/groups/#{node_group_id}") do |request|
             request.body = node_group_model
           end
@@ -43,6 +44,7 @@ module Scooter
 
         def update_node_group(node_group_id, update_hash)
           set_classifier_path
+          update_hash.delete('serial_number')
           @connection.post("v1/groups/#{node_group_id}") do |request|
             request.body = update_hash
           end


### PR DESCRIPTION
With the classifier changes in PE-23316, a new serial_number key has been added to the classifier payloads. We need to remove this when submitting an updated group hash, as including it can cause tests to fail due to a 409 response from the classifier.