### PR TITLE
(maint) remove serial number, last edited in classifier

### DIFF
--- a/lib/scooter/httpdispatchers/classifier.rb
+++ b/lib/scooter/httpdispatchers/classifier.rb
@@ -291,6 +291,9 @@ module Scooter
           node_group_model.delete('deleted') if node_group_model['deleted'] == {}
         end
 
+        node_group_model.delete('serial_number')
+        node_group_model.delete('last_edited')
+
         response.env.body.delete('serial_number')
         response.env.body.delete('last_edited')
         if node_group_model != response.env.body


### PR DESCRIPTION
This commit removes the serial_number and last_edited keys
in the classifier dispatcher so they will not invalidate the
equality check.