### PR TITLE
(maint) Add plan_jobs/:id endpoint

### DIFF
--- a/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
+++ b/lib/scooter/httpdispatchers/orchestrator/v1/v1.rb
@@ -130,6 +130,10 @@ module Scooter
             req.body = payload
           end
         end
+
+        def get_plan_job(plan_job_id)
+          @connection.get("#{@version}/plan_jobs/#{plan_job_id}")
+        end
       end
     end
   end


### PR DESCRIPTION
Add an endpoint for retrieving individual plan jobs, available in a
future 2018.1 release.