### PR TITLE
(BOLT-731) Add scooter endpoints for pe-bolt-server

### DIFF
--- a/lib/scooter/httpdispatchers.rb
+++ b/lib/scooter/httpdispatchers.rb
@@ -1,4 +1,4 @@
-%w( httpdispatcher consoledispatcher puppetdbdispatcher orchestratordispatcher).each do |lib|
+%w( httpdispatcher consoledispatcher puppetdbdispatcher orchestratordispatcher peboltserver_dispatcher).each do |lib|
   require "scooter/httpdispatchers/#{lib}"
 end
 

--- a/lib/scooter/httpdispatchers/peboltserver_dispatcher.rb
+++ b/lib/scooter/httpdispatchers/peboltserver_dispatcher.rb
@@ -1,0 +1,18 @@
+module Scooter
+  module HttpDispatchers
+    class PEBoltServerDispatcher < HttpDispatcher
+
+      def initialize(host)
+        super(host)
+        @connection.url_prefix.port = 8144
+      end
+
+      # @return [Faraday::Response] response object from Faraday http client
+      def ssh_run_task(task)
+        @connection.post("ssh/run_task") do |req|
+          req.body = task
+        end
+      end
+    end
+  end
+end

--- a/spec/scooter/httpdispatchers/peboltserver_dispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/peboltserver_dispatcher_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe Scooter::HttpDispatchers::PEBoltServerDispatcher do
+
+  let(:pe_bolt_server_api) { Scooter::HttpDispatchers::PEBoltServerDispatcher.new(host) }
+  let(:logger) { double('logger')}
+  let(:task) {
+    {
+      "target": {
+        "host": "", 
+        "user": "bolt",
+        "password": "bolt",
+        "host-key-check": "false"
+      },  
+      "task": {
+        "metadata": {
+          "description": "Echo a message",
+          "parameters": {
+            "message": "Default string"
+          },  
+          "file_content": "IyEvdXNyL2Jpbi9lbnYgYmFzaAplY2hvICRQVF9tZXNzYWdlCg=="
+        }   
+      },  
+      "parameters": {
+        "message": "Hello world"
+      }
+    }
+  }
+
+  unixhost = { roles:     ['test_role'],
+               platform: 'debian-9-x86_64' }
+  let(:host) { Beaker::Host.create('test.com', unixhost, {:logger => logger}) }
+
+  subject { pe_bolt_server_api }
+
+  before do
+    expect(OpenSSL::PKey).to receive(:read).and_return('Pkey')
+    expect(OpenSSL::X509::Certificate).to receive(:new).and_return('client_cert')
+    allow_any_instance_of(Scooter::HttpDispatchers::PEBoltServerDispatcher).to receive(:get_host_cert) {'host cert'}
+    allow_any_instance_of(Scooter::HttpDispatchers::PEBoltServerDispatcher).to receive(:get_host_private_key) {'key file'}
+    allow_any_instance_of(Scooter::HttpDispatchers::PEBoltServerDispatcher).to receive(:get_host_cacert) {'cert file'}
+    expect(subject).to be_kind_of(Scooter::HttpDispatchers::PEBoltServerDispatcher)
+    allow_any_instance_of(Beaker::Http::FaradayBeakerLogger).to receive(:debug) {true}
+    allow_any_instance_of(Beaker::Http::FaradayBeakerLogger).to receive(:info) {true}
+  end
+
+  it 'should make requests on the correct port' do
+    expect(pe_bolt_server_api.connection.url_prefix.port).to be(8144)
+  end
+
+  describe '.ssh_run_task' do
+
+    it { is_expected.to respond_to(:ssh_run_task).with(1).arguments }
+
+    it 'should take a job_id' do
+      expect(pe_bolt_server_api.connection).to receive(:post).with("ssh/run_task")
+      expect{ pe_bolt_server_api.ssh_run_task(task) }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This adds a new http dispatcher for pe-bolt-server, and the first endpoint
`ssh/run_task`.  I opted to include all methods directly in the
`PEBoltServerDispatcher` class rather than have a separate `PEBolt::V1` class
for the public methods because it seems much simpler and less confusing for new
comers. This does break the pattern used here, but I'm willing to sacrifice
consistency for simplicity.