### PR TITLE
(PE-24909) Update Scooter to be comptable with Beaker 4.0

### DIFF
--- a/lib/scooter.rb
+++ b/lib/scooter.rb
@@ -5,7 +5,6 @@ require 'beaker-http'
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday-cookie_jar'
-require 'nokogiri'
 
 module Scooter
   %w( utilities httpdispatchers ldap ).each do |lib|

--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '~> 1.8'
   spec.add_runtime_dependency 'test-unit'
   spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1', '<= 0.12.1'
-  spec.add_runtime_dependency 'beaker', '~> 3.0'
+  spec.add_runtime_dependency 'beaker', '>= 3.0.0'
   spec.add_runtime_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'


### PR DESCRIPTION
This PR removes the last reference to nokogiri and allows installs of Beaker
greater then 3.