### PR TITLE
(maint) Fix ca cert acquisition

### DIFF
--- a/lib/scooter/httpdispatchers/consoledispatcher.rb
+++ b/lib/scooter/httpdispatchers/consoledispatcher.rb
@@ -76,14 +76,14 @@ module Scooter
       # not a certificate dispatcher, but representing an LDAP or local user. If
       # credentials are supplied during initialization, then this overrides the
       # parent class and only acquires a ca_cert.
-      def acquire_ssl_components(host=self.host)
+      def configure_private_key_and_cert_with_puppet(host=self.host)
         if credentials == nil
           super(host)
         else
           if !host.is_a?(Unix::Host)
             raise 'Can only acquire SSL certs if the host is a Unix::Host'
           end
-          acquire_ca_cert(host)
+          configure_cacert_with_puppet(host)
         end
       end
 

--- a/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
@@ -9,22 +9,20 @@ module Scooter
     let(:username) {'Ziggy'}
     let(:password) {'Stardust'}
     let(:mock_page) {double('mock_page')}
+    let(:logger) { double('logger')}
 
     subject { HttpDispatchers::ConsoleDispatcher.new(host, credentials) }
 
     context 'with a beaker host passed in' do
-      let(:logger) { double('logger')}
       unixhost = { roles:     ['test_role'],
                    'platform' => 'debian-7-x86_64' }
       let(:host) { Beaker::Host.create('test.com', unixhost, {:logger => logger}) }
       before do
-        allow_any_instance_of(Beaker::Http::FaradayBeakerLogger).to receive(:info) { true }
-        allow_any_instance_of(Beaker::Http::FaradayBeakerLogger).to receive(:debug) { true }
-        expect(OpenSSL::PKey).to receive(:read).and_return('Pkey')
-        expect(OpenSSL::X509::Certificate).to receive(:new).and_return('client_cert')
-        allow_any_instance_of(HttpDispatchers::HttpDispatcher).to receive(:get_host_cert) {'host cert'}
-        allow_any_instance_of(HttpDispatchers::HttpDispatcher).to receive(:get_host_private_key) {'key file'}
-        allow_any_instance_of(HttpDispatchers::HttpDispatcher).to receive(:get_host_cacert) {'cert file'}
+        allow(logger).to receive(:info) {true}
+        allow(logger).to receive(:debug) {true}
+        expect(OpenSSL::PKey).not_to receive(:read)
+        expect(OpenSSL::X509::Certificate).not_to receive(:new)
+        allow_any_instance_of(HttpDispatchers::ConsoleDispatcher).to receive(:configure_cacert_with_puppet).and_return('cacert')
         expect(subject).to be_kind_of(HttpDispatchers::ConsoleDispatcher)
       end
 


### PR DESCRIPTION
The ca cert methods weren't updated when the port to use beaker-http was done;
this change updates it to use the defined methods from beaker-http.