### PR TITLE
(maint) Require resolv explicitly in HttpDispatcher

### DIFF
--- a/lib/scooter/httpdispatchers/httpdispatcher.rb
+++ b/lib/scooter/httpdispatchers/httpdispatcher.rb
@@ -1,3 +1,5 @@
+require 'resolv'
+
 module Scooter
   module HttpDispatchers
 


### PR DESCRIPTION
Previously, the use of `Resolv.getaddress` in the HTTPDispatcher would
fail in some beaker contexts because the resolve module was not
explicitly required.