### PR TITLE
(maint) update faraday to 0.17

### DIFF
--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json', '~> 1.8'
   spec.add_runtime_dependency 'test-unit'
   spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1', '<= 0.12.1'
-  spec.add_runtime_dependency 'faraday', '0.15.4' # v0.16.0 broke compatibility with faraday_middleware
+  spec.add_runtime_dependency 'faraday', '~> 0.17'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'
 end


### PR DESCRIPTION
This commit updates faraday to the last of the 0. releases for
compatibility with vmfloaty.