### PR TITLE
(PE-29973) add beaker-http to scooter directly

### DIFF
--- a/lib/beaker-http/dsl/web_helpers.rb
+++ b/lib/beaker-http/dsl/web_helpers.rb
@@ -1,0 +1,62 @@
+module Beaker::DSL::Helpers::WebHelpers
+
+  # Generates a new http connection object, using the ever-present options hash to
+  # configure the connection.
+  #
+  # @param host [Beaker::Host optional] supply a SUT host object; will use puppet on host
+  #    to configure certs, and use the options in the host object instead of the global.
+  # @return [Beaker::Http::Connection] an object wrapping the Faraday::Connection object.
+  def generate_new_http_connection(host = nil)
+    if host
+      raise ArgumentError.new "host must be Beaker::Host, not #{host.class}" if !host.is_a?(Beaker::Host)
+      connection = Beaker::Http::Connection.new(host.options)
+      connection.configure_private_key_and_cert_with_puppet(host)
+      connection
+    else
+      Beaker::Http::Connection.new(options)
+    end
+  end
+
+  # Make a single http request and discard the http connection object. Returns a Faraday::Response
+  # object that can be introspected for all response information.
+  #
+  # @param url [String] String that will be parsed into a URI object.
+  # @param request_method [Symbol] Represents any valid http verb.
+  # @param cert [OpenSSL::X509::Certificate] Certifcate for authentication.
+  # @param key [OpenSSL::PKey::RSA] Private Key for authentication.
+  # @param body [String, Hash] For requests that can send a body. Strings are sent unformatted and
+  #    Hashes are JSON.parsed by the Faraday Middleware.
+  # @param [Hash] options Hash of options extra options for the request
+  # @option options [Boolean] :read_timeout How long to wait before closing the connection.
+  # @return [Faraday::Response]
+  def http_request(url, request_method, cert=nil, key=nil, body=nil, options={})
+    connection = generate_new_http_connection
+
+
+    connection.url_prefix = URI.parse(url)
+
+    if cert
+      if cert.is_a?(OpenSSL::X509::Certificate)
+        connection.ssl['client_cert'] = cert
+      else
+        raise TypeError, "cert must be an OpenSSL::X509::Certificate object, not #{cert.class}"
+      end
+    end
+
+    if key
+      if key.is_a?(OpenSSL::PKey::RSA)
+        connection.ssl['client_key'] = key
+      else
+        raise TypeError, "key must be an OpenSSL::PKey:RSA object, not #{key.class}"
+      end
+    end
+
+    # ewwww
+    connection.ssl[:verify] = false
+
+    connection.connection.options.timeout = options[:read_timeout] if options[:read_timeout]
+
+    response = connection.send(request_method) { |conn| conn.body = body }
+    response
+  end
+end

--- a/lib/beaker-http/helpers/puppet_helpers.rb
+++ b/lib/beaker-http/helpers/puppet_helpers.rb
@@ -1,0 +1,49 @@
+module Beaker
+  module Http
+    module Helpers
+
+      # Given a Beaker::Host object, introspect the host for the CA cert and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the CA cert
+      # @return [String] File path to the CA cert saved on the coordinator
+      def get_host_cacert(host)
+        cacert_on_host= host.puppet['localcacert']
+        # puppet may not have laid down the cacert yet, so check to make sure
+        # the file exists
+        host.execute("test -f #{cacert_on_host}")
+        ca_cert = host.execute("cat #{cacert_on_host}", :silent => true)
+        cert_dir = Dir.mktmpdir("pe_certs")
+        ca_cert_file = File.join(cert_dir, "cacert.pem")
+        File.open(ca_cert_file, "w+") do |f|
+          f.write(ca_cert)
+        end
+        ca_cert_file
+      end
+
+      # Given a Beaker::Host object, introspect the host for the private key and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the private key
+      # @return [String] A String of the private key
+      def get_host_private_key(host)
+        private_key = host.puppet['hostprivkey']
+        # puppet may not have laid down the private_key yet, so check to make sure
+        # the file exists
+        host.execute("test -f #{private_key}")
+        host.execute("cat #{private_key}", :silent => true)
+      end
+
+      # Given a Beaker::Host object, introspect the host for the host cert and save it to
+      # the coordinator's filesystem.
+      # @param host[Beaker::Host] host to ssh into and find the host cert
+      # @return [String] A String of the host cert
+      def get_host_cert(host)
+        hostcert = host.puppet['hostcert']
+        # puppet may not have laid down the hostcert yet, so check to make sure
+        # the file exists
+        host.execute("test -f #{hostcert}")
+        host.execute("cat #{hostcert}", :silent => true)
+      end
+
+    end
+  end
+end

--- a/lib/beaker-http/http.rb
+++ b/lib/beaker-http/http.rb
@@ -1,0 +1,93 @@
+module Beaker
+  module Http
+
+    # == Beaker::Http::Connection object instantiation examples
+    # These examples are for using the Connection object directly. If you are trying to use
+    # this from within a test, consider using the
+    # {Beaker::DSL::Helpers::WebHelpers DSL constructors} instead.
+    # @see Beaker::DSL::Helpers::WebHelpers
+    class Connection
+      include Beaker::Http::Helpers
+      extend Forwardable
+
+      attr_reader :connection
+
+      # Beaker::Http::Connection objects can be instantiated with object that
+      # utilizes a  object for easier setup during testing.
+      #
+      # @param [Hash] options Typically the global options provided by Beaker.
+      # @option options [Beaker::Logger] :logger
+      # @option options [Boolean] :log_http_bodies
+      def initialize(options)
+        @connection = create_default_connection(options)
+      end
+
+      def_delegators :connection, :get, :post, :put, :delete, :head, :patch, :url_prefix, :url_prefix=, :ssl
+
+      def create_default_connection(options)
+        Faraday.new do |conn|
+          conn.request :json
+
+          conn.response :follow_redirects
+          conn.response :raise_error
+          conn.response :json, :content_type => /\bjson$/
+
+          # We can supply a third argument, a Hash with key of :bodies set to true or false,
+          # to configure whether or not to log http bodies in requests and responses.
+          # However, to uncomplicate things, we will just use the default
+          # set in the middleware and not allow the http log level to be set
+          # independently of the beaker log level. If we find that we should allow setting
+          # of http bodies independent of the beaker log level, we should expose that setting
+          # here.
+          conn.response :faraday_beaker_logger, options[:logger]
+
+          conn.adapter :net_http
+        end
+      end
+
+      # If you would like to run tests that expect 400 or even 500 responses,
+      # apply this method to remove the <tt>:raise_error</tt> middleware.
+      def remove_error_checking
+        connection.builder.delete(Faraday::Response::RaiseError)
+        nil
+      end
+
+      def set_cacert(ca_file)
+        ssl['ca_file'] = ca_file
+        url_prefix.scheme = 'https'
+      end
+
+      def set_client_key(client_key)
+        ssl['client_key'] = client_key
+      end
+
+      def set_client_cert(client_cert)
+        ssl['client_cert'] = client_cert
+      end
+
+      # Use this method if you are connecting as a user to the system; it will
+      # provide the correct SSL context but not provide authentication.
+      def configure_cacert_with_puppet(host)
+        set_cacert(get_host_cacert(host))
+        connection.host = host.hostname
+        nil
+      end
+
+      # Use this method if you want to connect to the system using certificate
+      # based authentication. This method will provide the ssl context and use
+      # the private key and cert from the host provided for authentication.
+      def configure_private_key_and_cert_with_puppet(host)
+        configure_cacert_with_puppet(host)
+
+        client_key_raw = get_host_private_key(host)
+        client_cert_raw = get_host_cert(host)
+
+        ssl['client_key'] = OpenSSL::PKey.read(client_key_raw)
+        ssl['client_cert'] = OpenSSL::X509::Certificate.new(client_cert_raw)
+
+        nil
+      end
+
+    end
+  end
+end

--- a/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
+++ b/lib/beaker-http/middleware/response/faraday_beaker_logger.rb
@@ -1,0 +1,60 @@
+module Beaker
+  module Http
+    class FaradayBeakerLogger < Faraday::Response::Middleware
+      extend Forwardable
+
+      DEFAULT_OPTIONS = { :bodies => true }
+
+      def initialize(app, logger, options = {} )
+        super(app)
+        @logger = logger
+        @options = DEFAULT_OPTIONS.merge(options)
+      end
+
+      def_delegators :@logger, :trace, :debug, :info, :notify, :warn
+
+      def call(env)
+        @start_time = Time.now
+        info "#{env.method.upcase}: #{env.url.to_s}"
+        debug "REQUEST HEADERS:\n#{dump_headers env.request_headers}"
+        debug "REQUEST BODY:\n#{dump_body env[:body]}" if env[:body] && log_body?(:request)
+        super
+      end
+
+      def on_complete(env)
+        info "RESPONSE CODE: #{env.status.to_s}"
+        debug "ELAPSED TIME: #{Time.now - @start_time}"
+        debug "RESPONSE HEADERS:\n#{dump_headers env.response_headers}"
+        debug "RESPONSE BODY:\n#{dump_body env[:body]}" if env[:body] && log_body?(:response)
+      end
+      private
+
+      def dump_headers(headers)
+        headers.map { |k, v| "#{k}: #{v.inspect}" }.join("\n")
+      end
+
+      def pretty_inspect(body)
+        require 'pp' unless body.respond_to?(:pretty_inspect)
+        body.pretty_inspect
+      end
+
+      def dump_body(body)
+        if body.respond_to?(:to_str)
+          body.to_str
+        else
+          pretty_inspect(body)
+        end
+      end
+
+      def log_body?(type)
+        case @options[:bodies]
+        when Hash then @options[:bodies][type]
+        else @options[:bodies]
+      end
+    end
+
+    end
+  end
+end
+
+Faraday::Response.register_middleware :faraday_beaker_logger => lambda { Beaker::Http::FaradayBeakerLogger }

--- a/lib/beaker-http/version.rb
+++ b/lib/beaker-http/version.rb
@@ -1,0 +1,7 @@
+module Beaker
+  module Http
+    module Version
+      STRING = '0.2.0'
+    end
+  end
+end

--- a/lib/scooter.rb
+++ b/lib/scooter.rb
@@ -1,10 +1,14 @@
 require 'scooter/version'
 require 'beaker'
 require 'net/ldap'
-require 'beaker-http'
 require 'faraday'
 require 'faraday_middleware'
 require 'faraday-cookie_jar'
+require 'forwardable'
+require 'beaker-http/helpers/puppet_helpers'
+require 'beaker-http/dsl/web_helpers'
+require "beaker-http/http"
+require 'beaker-http/middleware/response/faraday_beaker_logger'
 
 module Scooter
   %w( utilities httpdispatchers ldap ).each do |lib|

--- a/scooter.gemspec
+++ b/scooter.gemspec
@@ -27,14 +27,13 @@ Gem::Specification.new do |spec|
   #Documentation dependencies
   spec.add_development_dependency 'yard', '~> 0.9.11'
   spec.add_development_dependency 'markdown', '~> 0'
-  spec.add_development_dependency 'activesupport', '4.2.6'
+  spec.add_development_dependency 'activesupport', '4.2.8'
 
   #Run time dependencies
   spec.add_runtime_dependency 'beaker', '>= 3.0', '< 5.0' # known support for beaker 3.x and 4.x
-  spec.add_runtime_dependency 'beaker-http', '~> 0.0'
-  spec.add_runtime_dependency 'json', '~> 1.8'
+  spec.add_runtime_dependency 'json', '>= 2.3.0'
   spec.add_runtime_dependency 'test-unit'
-  spec.add_runtime_dependency 'net-ldap', '~> 0.6', '>= 0.6.1', '<= 0.12.1'
+  spec.add_runtime_dependency 'net-ldap', '~> 0.16.0'
   spec.add_runtime_dependency 'faraday', '~> 0.17'
   spec.add_runtime_dependency 'faraday_middleware', '~> 0.9'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0', '>= 0.0.6'


### PR DESCRIPTION
This commit was created to address [CVE-2020-10663](https://app.snyk.io/org/puppet-enterprise/project/27bb8f93-69ed-45d3-a331-13089541296d#issue-SNYK-RUBY-JSON-560838) and [CVE-2017-17718](https://app.snyk.io/org/puppet-enterprise/project/27bb8f93-69ed-45d3-a331-13089541296d#issue-SNYK-RUBY-NETLDAP-22008). Bumping the json and net-ldap dependencies required also bumping the add-development_dependency, and adding http-beaker directly to scooter. http-beaker is arcived so dependency bumps there were not possible until it was added in here. Currently, when manually testing scooter it is already failing with hiera issues before I made any changes. It is impossible to test the changes made here because of that. This is a WIP