### PR TITLE
(PE-37639) fetch login page prior to logging in

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Scooter is currently divvied into the following sections:
 ## Running the tests
 
 ```
-bundle exec rake spec
+bundle exec rake test
 ```
 
 ## Versioning

--- a/lib/scooter/httpdispatchers/consoledispatcher.rb
+++ b/lib/scooter/httpdispatchers/consoledispatcher.rb
@@ -88,8 +88,13 @@ module Scooter
       end
 
       def signin(login=self.credentials.login, password=self.credentials.password)
+        response = @connection.get "/auth/login"
+        return response if response.status != 200
+        # extract the session cookie, if it is present
+        cookie = response.headers['Set-Cookie']
         response = @connection.post "/auth/login" do |request|
           request.headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8'
+          request.headers['Cookie'] = cookie if cookie
           request.body = "username=#{login}&password=#{CGI.escape(password)}"
           connection.port = 443
         end

--- a/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
+++ b/spec/scooter/httpdispatchers/consoledispatcher_spec.rb
@@ -28,6 +28,12 @@ module Scooter
 
       context '"signin with a page that returns a token' do
         before do
+          stub_request(:get, /auth\/login/).
+            to_return(status: 200,
+                      body: '',
+                      headers: {
+                        "set-cookie"=>"__HOST-somecookie=something;Secure;Path=/",
+                      })
           stub_request(:post, /auth\/login/).
             to_return(status: 200,
                       body: '',
@@ -35,7 +41,7 @@ module Scooter
                                 "date"=>"Tue, 29 Nov 2016 22:05:41 GMT",
                                 "content-length"=>"0",
                                 "connection"=>"close",
-                                "set-cookie"=>"JSESSIONID=b05e9b11-5e9f-4d6a-9faf-e28a0415197d; Path=/; Secure; HttpOnly, rememberMe=deleteMe; Path=/auth; Max-Age=0; Expires=Mon, 28-Nov-2016 22:05:41 GMT, pl_ssti=0CeHhpz5PPLna7kpaEMcTHjJ62z9eizHTzsxEXNK8W20;Secure;Path=/",
+                                "set-cookie"=>"__HOST-pl_ssti=0CeHhpz5PPLna7kpaEMcTHjJ62z9eizHTzsxEXNK8W20;Secure;Path=/",
                                 "location"=>"/",
                                 "x-frame-options"=>"DENY"})
 


### PR DESCRIPTION
In order to simulate the login flow accurately, this adds a request
to the login page prior to posting a login request. The cookie is
extracted from the login page response (via Set-Cookie), and if it
is present, is included as a cookie in the POST to the login request
page.

Tests are updated to add a stub for the login page request prior
to the post.